### PR TITLE
Ajout d'un client PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+/vendor/

--- a/bin/encode
+++ b/bin/encode
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+require 'vendor/autoload.php';
+
+use Firebase\JWT\JWT;
+
+function exit_usage() {
+    echo "Too few arguments\n";
+    echo "Usage: bin/encode <id> <token> \n";
+    exit(1);
+}
+
+if ($argc !== 3) {
+    exit_usage();
+}
+
+$id = $argv[1];
+$token = $argv[2];
+
+$payload = [
+    'id' => $id,
+    'scope' => 'localtest',
+    'exp' => time() + (60 * 60),
+];
+
+$jwt = JWT::encode($payload, $token);
+
+echo "JSON Web Token generated!\n\n";
+echo "{$jwt}\n";

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "betagouv/mes-aides-out",
+    "require": {
+        "firebase/php-jwt": "^5.0"
+    },
+    "autoload": {
+        "psr-4": { "": "src/php" }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "betagouv/mes-aides-out",
     "require": {
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^5.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "autoload": {
         "psr-4": { "": "src/php" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,64 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "3f8feb98f8d68e75c7a30b8344b9f470",
+    "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
+                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": " 4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "time": "2017-06-27T22:17:23+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f8feb98f8d68e75c7a30b8344b9f470",
+    "content-hash": "0df44a31a539501d3aac9d9e3edc6337",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -51,6 +51,237 @@
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
             "time": "2017-06-27T22:17:23+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [],

--- a/examples/php/index.php
+++ b/examples/php/index.php
@@ -1,0 +1,27 @@
+<?php
+
+$data = array(
+    'date_naissance_dem' => '1940-12-12',
+    'situationfam_dem' => 'Célibataire',
+    'salaire_dem' => 800 * 2,
+    'montantRetraite_dem' => 500 * 12,
+    'allocations_dem' => 200 * 12
+);
+
+setcookie('payload', base64_encode(json_encode($data)));
+
+?>
+<html>
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <p>Les informations suivantes seront envoyées au téléservice : </p>
+        <ul>
+        <?php foreach ($data as $key => $value) : ?>
+            <li><?php echo "{$key} = {$value}" ?></li>
+        <?php endforeach; ?>
+        </ul>
+        <a href="teleservice.php?code=<?php echo md5(rand()) ?>">Accéder au téléservice</a>
+    </body>
+</html>

--- a/examples/php/teleservice.php
+++ b/examples/php/teleservice.php
@@ -1,0 +1,43 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use BetaGouv\MesAides\SituationProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+$payload = $_COOKIE['payload'];
+$body = base64_decode($payload);
+setcookie('payload', '', time() - 3600);
+
+$mock = new MockHandler([
+    new Response(200, [], $body),
+]);
+
+$handler = HandlerStack::create($mock);
+$client = new Client(['handler' => $handler]);
+
+$sp = new SituationProvider('foo', 'bar', $client);
+
+$data = $sp->fromToken($token);
+
+?>
+<html>
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <p>Les informations ont été renvoyées : </p>
+        <form>
+        <?php foreach ($data as $key => $value) : ?>
+            <p>
+                <label><?php echo $key ?></label>
+                <input name="<?php echo $key ?>" value="<?php echo $value ?>">
+            </p>
+        <?php endforeach; ?>
+        </form>
+        <a href="index.php">Retour</a>
+    </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -50,3 +50,8 @@ Pour fonctionner il faut spécifier le bon prefix
 MES_AIDES_CALLBACK_PREFIX=http://localhost:3000/data?
 MES_AIDES_CALLBACK_PREFIX=http://localhost:3000/secured-data?
 ```
+
+
+```
+php -S localhost:8000 -t examples/php
+```

--- a/src/php/BetaGouv/MesAides/SituationProvider.php
+++ b/src/php/BetaGouv/MesAides/SituationProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BetaGouv\MesAides;
+
+class SituationProvider
+{
+    private $baseUrl;
+    private $username;
+    private $password;
+
+    public function __construct($baseUrl, $username, $password)
+    {
+        $this->baseUrl = $baseUrl;
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function fromToken($token)
+    {
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, "{$this->baseUrl}/api/situations/via/{$token}");
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+
+        // TODO Send authentication headers
+        // curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        // curl_setopt($curl, CURLOPT_USERPWD, "{$this->username}:{$this->password}");
+
+        $response = curl_exec($curl);
+
+        if (false !== $response) {
+            return json_decode($response, true);
+        }
+    }
+}


### PR DESCRIPTION
Désolé j'ai eu un peu de mal à trouver une technique pas trop dégueu pour les stubs des réponses. 

J'ai retenu le [Mock Handler de Guzzle](http://docs.guzzlephp.org/en/stable/testing.html#mock-handler), le client HTTP de référence en PHP. 
Ça ajoute une dépendance, mais ça va nous permettre de tester la libraire également. 

Donc l'idée c'est qu'on peut passer un 3ème paramètre optionnel à la classe `SituationProvider`, qui est le client HTTP en lui-même (voir `teleservice.php`), et on mock les réponses (ça ne tape même pas vraiment le serveur). 

Pour tester : 

```
php -S localhost:8000 -t examples/php
```

Ça lance l'exemple en utilisant le [serveur web interne](http://php.net/manual/fr/features.commandline.webserver.php). 
L'exemple écrit juste les données dans un cookie, et sur la page du téléservice, ça utilise les données du cookie pour mocker les réponses. 

![teleservice](https://user-images.githubusercontent.com/1162230/42173011-030fdb4a-7e1e-11e8-9b51-0ab5e2d23db6.gif)

@guillett si l'idée te convient, je continue dans ce sens. 

**NB** Ne pas tenir compte du script `bin/encode`, je m'en servais pour mes tests. 
